### PR TITLE
Centralize environment loading

### DIFF
--- a/admin/packages/create.php
+++ b/admin/packages/create.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../../bootstrap.php';
 require_once __DIR__ . '/../../app/Database.php';
 require_once __DIR__ . '/../../app/Models/Package.php';
 

--- a/admin/packages/edit.php
+++ b/admin/packages/edit.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../../bootstrap.php';
 require_once __DIR__ . '/../../app/Database.php';
 require_once __DIR__ . '/../../app/Models/Package.php';
 

--- a/admin/packages/index.php
+++ b/admin/packages/index.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../../bootstrap.php';
 require_once __DIR__ . '/../../app/Database.php';
 require_once __DIR__ . '/../../app/Models/Package.php';
 

--- a/app/Database.php
+++ b/app/Database.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../vendor/autoload.php';
-
-use Dotenv\Dotenv;
 
 class Database
 {
@@ -13,16 +10,12 @@ class Database
 
     /**
      * Database constructor.
-     *
-     * Loads environment variables and establishes the PDO connection.
+     * Establishes the PDO connection using environment variables.
      *
      * @throws PDOException If the connection fails.
      */
     public function __construct()
     {
-        $dotenv = Dotenv::createUnsafeImmutable(__DIR__ . '/..');
-        $dotenv->safeLoad();
-
         $host = getenv('DB_HOST');
         $name = getenv('DB_NAME');
         $user = getenv('DB_USER');

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../Database.php';
 
 /**
  * Model for lesson packages.

--- a/app/Models/Purchase.php
+++ b/app/Models/Purchase.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../Database.php';
 
 /**
  * Model for purchases records.

--- a/app/PaymentHandler.php
+++ b/app/PaymentHandler.php
@@ -1,6 +1,5 @@
 <?php
 
-require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/Models/Purchase.php';
 require_once __DIR__ . '/Models/Package.php';
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Dotenv\Dotenv;
+
+if (file_exists(__DIR__ . '/.env')) {
+    Dotenv::createUnsafeImmutable(__DIR__)->safeLoad();
+}

--- a/checkout.php
+++ b/checkout.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/Database.php';
 require_once __DIR__ . '/app/Models/Package.php';
 require_once __DIR__ . '/app/Models/Purchase.php';

--- a/contact-handler.php
+++ b/contact-handler.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit bootstrap="bootstrap.php"
          colors="true"
          verbose="true"
 >

--- a/scripts/run-migrations.php
+++ b/scripts/run-migrations.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../app/Database.php';
 
 try {

--- a/stripe_webhook.php
+++ b/stripe_webhook.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/Database.php';
 require_once __DIR__ . '/app/Models/Purchase.php';
 require_once __DIR__ . '/app/Models/Package.php';


### PR DESCRIPTION
## Summary
- add a single `bootstrap.php` file that loads Composer and Dotenv
- have Database constructor only read from getenv
- include `bootstrap.php` in all entrypoints
- use `bootstrap.php` as PHPUnit bootstrap

## Testing
- `./vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0b81438832991b87cf0619c303f