### PR TITLE
Add PHP type hints for models and handler

### DIFF
--- a/app/Database.php
+++ b/app/Database.php
@@ -7,9 +7,11 @@ use Dotenv\Dotenv;
 class Database
 {
     /**
+     * PDO connection instance.
+     *
      * @var PDO
      */
-    private $connection;
+    private PDO $connection;
 
     /**
      * Database constructor.
@@ -44,7 +46,7 @@ class Database
      *
      * @return PDO
      */
-    public function getConnection()
+    public function getConnection(): PDO
     {
         return $this->connection;
     }

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -2,19 +2,20 @@
 
 require_once __DIR__ . '/../Database.php';
 
+
 /**
  * Model for lesson packages.
  */
 class Package
 {
     /** @var PDO */
-    private $pdo;
+    private PDO $pdo;
 
     /**
      * Package constructor.
      * @param PDO $pdo
      */
-    public function __construct($pdo)
+    public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
     }
@@ -23,7 +24,7 @@ class Package
      * Get all packages.
      * @return array
      */
-    public function getAll()
+    public function getAll(): array
     {
         $stmt = $this->pdo->query('SELECT * FROM packages');
         return $stmt->fetchAll();
@@ -34,7 +35,7 @@ class Package
      * @param int $id
      * @return array|null
      */
-    public function getById($id)
+    public function getById(int $id): ?array
     {
         $stmt = $this->pdo->prepare('SELECT * FROM packages WHERE id = :id');
         $stmt->execute(['id' => $id]);
@@ -51,7 +52,7 @@ class Package
      * @param bool $active
      * @return int Inserted package ID
      */
-    public function create($name, $description, $creditAmount, $priceCents, $active = true)
+    public function create(string $name, string $description, int $creditAmount, int $priceCents, bool $active = true): int
     {
         $stmt = $this->pdo->prepare(
             'INSERT INTO packages (name, description, credit_amount, price_cents, active)
@@ -77,7 +78,7 @@ class Package
      * @param bool $active
      * @return bool
      */
-    public function update($id, $name, $description, $creditAmount, $priceCents, $active)
+    public function update(int $id, string $name, string $description, int $creditAmount, int $priceCents, bool $active): bool
     {
         $stmt = $this->pdo->prepare(
             'UPDATE packages SET name = :name, description = :description,
@@ -99,7 +100,7 @@ class Package
      * @param int $id
      * @return bool
      */
-    public function delete($id)
+    public function delete(int $id): bool
     {
         $stmt = $this->pdo->prepare('DELETE FROM packages WHERE id = :id');
         return $stmt->execute(['id' => $id]);
@@ -111,7 +112,7 @@ class Package
      * @param bool $active
      * @return bool
      */
-    public function toggleActive($id, $active)
+    public function toggleActive(int $id, bool $active): bool
     {
         $stmt = $this->pdo->prepare('UPDATE packages SET active = :active WHERE id = :id');
         return $stmt->execute([
@@ -120,3 +121,4 @@ class Package
         ]);
     }
 }
+

--- a/app/Models/Purchase.php
+++ b/app/Models/Purchase.php
@@ -2,19 +2,20 @@
 
 require_once __DIR__ . '/../Database.php';
 
+
 /**
  * Model for purchases records.
  */
 class Purchase
 {
     /** @var PDO */
-    private $pdo;
+    private PDO $pdo;
 
     /**
      * Purchase constructor.
      * @param PDO $pdo
      */
-    public function __construct($pdo)
+    public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
     }
@@ -28,7 +29,7 @@ class Purchase
      * @param string $status
      * @return int Inserted purchase ID
      */
-    public function create($userId, $packageId, $stripeSessionId, $amountCents, $status)
+    public function create(int $userId, int $packageId, string $stripeSessionId, int $amountCents, string $status): int
     {
         $stmt = $this->pdo->prepare(
             'INSERT INTO purchases (user_id, package_id, stripe_session_id, amount_cents, status)
@@ -50,7 +51,7 @@ class Purchase
      * @param string $stripeSessionId
      * @return bool
      */
-    public function updateSessionId($id, $stripeSessionId)
+    public function updateSessionId(int $id, string $stripeSessionId): bool
     {
         $stmt = $this->pdo->prepare(
             'UPDATE purchases SET stripe_session_id = :stripe_session_id WHERE id = :id'
@@ -67,7 +68,7 @@ class Purchase
      * @param string $status
      * @return bool
      */
-    public function updateStatusById($id, $status)
+    public function updateStatusById(int $id, string $status): bool
     {
         $stmt = $this->pdo->prepare(
             'UPDATE purchases SET status = :status, updated_at = CURRENT_TIMESTAMP WHERE id = :id'
@@ -83,7 +84,7 @@ class Purchase
      * @param int $id
      * @return array|null
      */
-    public function getById($id)
+    public function getById(int $id): ?array
     {
         $stmt = $this->pdo->prepare('SELECT * FROM purchases WHERE id = :id');
         $stmt->execute(['id' => $id]);

--- a/app/PaymentHandler.php
+++ b/app/PaymentHandler.php
@@ -13,13 +13,13 @@ use Stripe\Webhook;
 class PaymentHandler
 {
     /** @var StripeClient */
-    private $stripe;
+    private StripeClient $stripe;
     /** @var PDO */
-    private $pdo;
+    private PDO $pdo;
     /** @var Package */
-    private $packageModel;
+    private Package $packageModel;
     /** @var Purchase */
-    private $purchaseModel;
+    private Purchase $purchaseModel;
 
     /**
      * PaymentHandler constructor.
@@ -41,7 +41,7 @@ class PaymentHandler
      * @return string
      * @throws Exception
      */
-    public function createCheckoutSession($userId, $packageId, $successUrl, $cancelUrl)
+    public function createCheckoutSession(int $userId, int $packageId, string $successUrl, string $cancelUrl): string
     {
         $package = $this->packageModel->getById($packageId);
         if (!$package) {
@@ -86,7 +86,7 @@ class PaymentHandler
      * @param string $sigHeader
      * @param string $endpointSecret
      */
-    public function handleWebhook($payload, $sigHeader, $endpointSecret)
+    public function handleWebhook(string $payload, string $sigHeader, string $endpointSecret): void
     {
         $event = Webhook::constructEvent(
             $payload,
@@ -116,3 +116,4 @@ class PaymentHandler
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- strengthen typings in core PHP classes
- type-hint PDO connection in `Database`
- type-hint `Package` model methods
- type-hint `Purchase` model methods
- type-hint `PaymentHandler` methods

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6845b0f02bb0832982621d2f4958b2e8