### PR TITLE
Adopt PSR‑4 autoloading

### DIFF
--- a/admin/packages/create.php
+++ b/admin/packages/create.php
@@ -1,8 +1,9 @@
 <?php
 
+use App\Database\Database;
+use App\Models\Package;
+
 require_once __DIR__ . '/../../bootstrap.php';
-require_once __DIR__ . '/../../app/Database.php';
-require_once __DIR__ . '/../../app/Models/Package.php';
 
 $db = new Database();
 $pdo = $db->getConnection();

--- a/admin/packages/edit.php
+++ b/admin/packages/edit.php
@@ -1,8 +1,9 @@
 <?php
 
+use App\Database\Database;
+use App\Models\Package;
+
 require_once __DIR__ . '/../../bootstrap.php';
-require_once __DIR__ . '/../../app/Database.php';
-require_once __DIR__ . '/../../app/Models/Package.php';
 
 $db = new Database();
 $pdo = $db->getConnection();

--- a/admin/packages/index.php
+++ b/admin/packages/index.php
@@ -1,8 +1,9 @@
 <?php
 
+use App\Database\Database;
+use App\Models\Package;
+
 require_once __DIR__ . '/../../bootstrap.php';
-require_once __DIR__ . '/../../app/Database.php';
-require_once __DIR__ . '/../../app/Models/Package.php';
 
 $db = new Database();
 $pdo = $db->getConnection();

--- a/app/Database/Database.php
+++ b/app/Database/Database.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace App\Database;
+
+use PDO;
+use PDOException;
 
 class Database
 {

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -1,6 +1,8 @@
 <?php
 
+namespace App\Models;
 
+use PDO;
 
 /**
  * Model for lesson packages.

--- a/app/Models/Purchase.php
+++ b/app/Models/Purchase.php
@@ -1,6 +1,8 @@
 <?php
 
+namespace App\Models;
 
+use PDO;
 
 /**
  * Model for purchases records.

--- a/app/Payment/PaymentHandler.php
+++ b/app/Payment/PaymentHandler.php
@@ -1,10 +1,13 @@
 <?php
 
-require_once __DIR__ . '/Models/Purchase.php';
-require_once __DIR__ . '/Models/Package.php';
+namespace App\Payment;
 
+use App\Models\Purchase;
+use App\Models\Package;
 use Stripe\StripeClient;
 use Stripe\Webhook;
+use PDO;
+use Exception;
 
 /**
  * Handles Stripe checkout session creation and webhook events.

--- a/checkout.php
+++ b/checkout.php
@@ -1,11 +1,13 @@
 <?php
-session_start();
 
 require_once __DIR__ . '/bootstrap.php';
-require_once __DIR__ . '/app/Database.php';
-require_once __DIR__ . '/app/Models/Package.php';
-require_once __DIR__ . '/app/Models/Purchase.php';
-require_once __DIR__ . '/app/PaymentHandler.php';
+
+use App\Database\Database;
+use App\Models\Package;
+use App\Models\Purchase;
+use App\Payment\PaymentHandler;
+
+session_start();
 
 if (empty($_SESSION['user_id'])) {
     header('Location: login.php');

--- a/composer.json
+++ b/composer.json
@@ -5,5 +5,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
     }
 }

--- a/docs/USAGE_CONTACT_PAYMENT.md
+++ b/docs/USAGE_CONTACT_PAYMENT.md
@@ -15,7 +15,7 @@ This document summarizes how the contact form and payment checkout are implement
 
 ## PaymentHandler
 
-- `app/PaymentHandler.php` no longer creates its own dependencies. Instead it
+- `app/Payment/PaymentHandler.php` no longer creates its own dependencies. Instead it
   receives a PDO connection, `Package` model, `Purchase` model and a
   `\Stripe\StripeClient` instance via the constructor.
 - `createCheckoutSession()` builds a Stripe checkout session and records a

--- a/scripts/run-migrations.php
+++ b/scripts/run-migrations.php
@@ -1,7 +1,8 @@
 <?php
 
+use App\Database\Database;
+
 require_once __DIR__ . '/../bootstrap.php';
-require_once __DIR__ . '/../app/Database.php';
 
 try {
     $db = new Database();

--- a/stripe_webhook.php
+++ b/stripe_webhook.php
@@ -1,10 +1,11 @@
 <?php
 
+use App\Database\Database;
+use App\Models\Purchase;
+use App\Models\Package;
+use App\Payment\PaymentHandler;
+
 require_once __DIR__ . '/bootstrap.php';
-require_once __DIR__ . '/app/Database.php';
-require_once __DIR__ . '/app/Models/Purchase.php';
-require_once __DIR__ . '/app/Models/Package.php';
-require_once __DIR__ . '/app/PaymentHandler.php';
 
 $payload = @file_get_contents('php://input');
 $sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? '';

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -1,8 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-
-require_once __DIR__ . '/../app/Database.php';
+use App\Database\Database;
 
 class DatabaseTest extends TestCase
 {

--- a/tests/PackageModelTest.php
+++ b/tests/PackageModelTest.php
@@ -1,8 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-
-require_once __DIR__ . '/../app/Models/Package.php';
+use App\Models\Package;
 
 /**
  * Tests for the Package model using an in-memory SQLite database.

--- a/tests/PaymentHandlerTest.php
+++ b/tests/PaymentHandlerTest.php
@@ -32,7 +32,9 @@ namespace Stripe {
 
 namespace {
 use PHPUnit\Framework\TestCase;
-require_once __DIR__ . '/../app/PaymentHandler.php';
+use App\Payment\PaymentHandler;
+use App\Models\Package;
+use App\Models\Purchase;
 
 class PaymentHandlerTest extends TestCase
 {
@@ -64,9 +66,9 @@ class PaymentHandlerTest extends TestCase
         $userId = (int)$pdo->lastInsertId();
 
         $stripeStub = new \Stripe\StripeClient('sk_test');
-        $packageModel = new \Package($pdo);
-        $purchaseModel = new \Purchase($pdo);
-        $handler = new \PaymentHandler($pdo, $packageModel, $purchaseModel, $stripeStub);
+        $packageModel = new Package($pdo);
+        $purchaseModel = new Purchase($pdo);
+        $handler = new PaymentHandler($pdo, $packageModel, $purchaseModel, $stripeStub);
 
         $url = $handler->createCheckoutSession($userId, $packageId, 'http://success', 'http://cancel');
 
@@ -89,9 +91,9 @@ class PaymentHandlerTest extends TestCase
         $purchaseId = (int)$pdo->lastInsertId();
 
         $stripeStub = new \Stripe\StripeClient('sk_test');
-        $packageModel = new \Package($pdo);
-        $purchaseModel = new \Purchase($pdo);
-        $handler = new \PaymentHandler($pdo, $packageModel, $purchaseModel, $stripeStub);
+        $packageModel = new Package($pdo);
+        $purchaseModel = new Purchase($pdo);
+        $handler = new PaymentHandler($pdo, $packageModel, $purchaseModel, $stripeStub);
 
         $event = [
             'type' => 'checkout.session.completed',


### PR DESCRIPTION
## Summary
- register `App\` namespace for PSR-4
- move Database and PaymentHandler classes into namespaced directories
- namespace core classes and remove `require_once`
- update scripts and tests to use new namespaces
- refresh docs for new class paths

## Testing
- `composer dump-autoload`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6845b50044b0832981ef9e62b7bf7511