### PR TITLE
Fix missing nav/footer on flashcards

### DIFF
--- a/src/pages/blog/integration-flashcards/index.html
+++ b/src/pages/blog/integration-flashcards/index.html
@@ -381,8 +381,8 @@
 
         }); // End DOMContentLoaded
     </script>
-    <!-- Link to global script.txt if you have one for other functions -->
-    <!-- <script type="module" src="js/main.js"></script> --> <!-- Assuming you rename script.txt -->
+    <!-- Load global scripts (header, footer, animations, etc.) -->
+    <script type="module" src="js/main.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load global scripts on integration flashcards page to bring in header and footer components

## Testing
- `composer install` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c90f8924c8329916e41debb454b40